### PR TITLE
Adding error handler to avoid service kill when redis gone

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,6 +85,8 @@ var RedisStorage = createStorage(queue, unqueue, log);
  */
 RedisStorage.prototype.redis = function() {
     if (!this.cn) this.cn = redis.createClient();
+    // catch connection errors as service and so we can try reconnecting
+    this.cn.on('error', function() {true});
     return this.cn;
 };
 


### PR DESCRIPTION
Could be perhaps improved with some error loggings for higher verbose levels.

Conflicts:
	index.js